### PR TITLE
spell of embedding_3072 in helper file

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -327,6 +327,6 @@ if (! function_exists('get_embedding_size')) {
             return 'embedding_'.$size;
         }
 
-        return 'embeding_3072';
+        return 'embedding_3072';
     }
 }


### PR DESCRIPTION
spell of embedding_3072 is wrong in the helper function I think, It gives an error when its size does not match and returns the default option, its needs to embedding_3072 but its embeding_3072